### PR TITLE
feat: add collapsible content with unified fade effect

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -165,8 +165,12 @@ button#receivedBtn {
   height: 40px;
   background: linear-gradient(transparent, white);
   pointer-events: none;
-  opacity: 1;
+  opacity: 0;
   transition: opacity 0.3s ease-out;
+}
+
+.entry .content .content-wrapper:not(.expanded):has(+ .toggle-description)::after {
+  opacity: 1;
 }
 
 .entry .content .content-wrapper.expanded::after {

--- a/css/components.css
+++ b/css/components.css
@@ -111,6 +111,7 @@ button#receivedBtn {
 .entry .content {
   flex: 1;
   min-width: 0;
+  position: relative;
 }
 
 .entry .content .title {
@@ -140,10 +141,65 @@ button#receivedBtn {
   font-size: 0.95rem;
   color: var(--text-color);
   word-break: break-word;
-  max-height: 200px;
-  overflow-y: auto;
   display: block;
   white-space: pre-wrap;
+}
+
+.entry .content .content-wrapper {
+  max-height: 100px;
+  overflow-y: hidden;
+  position: relative;
+  transition: max-height 0.3s ease-out;
+}
+
+.entry .content .content-wrapper.expanded {
+  max-height: none;
+}
+
+.entry .content .content-wrapper::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 40px;
+  background: linear-gradient(transparent, white);
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.3s ease-out;
+}
+
+.entry .content .content-wrapper.expanded::after {
+  opacity: 0;
+}
+
+.entry .content .toggle-description {
+  display: block;
+  margin-top: 0.5rem;
+  padding: 0.5rem;
+  background: none;
+  border: none;
+  color: var(--primary-color);
+  font-size: 0.9rem;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  box-shadow: none;
+}
+
+.entry .content .toggle-description:hover {
+  text-decoration: underline;
+}
+
+.entry .content .toggle-description svg {
+  width: 12px;
+  height: 12px;
+  margin-left: 0.25rem;
+  transition: transform 0.3s ease-out;
+}
+
+.entry .content .content-wrapper.expanded + .toggle-description svg {
+  transform: rotate(180deg);
 }
 
 .entry .actions {

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     
     <div class="form-group">
       <label for="partner">相手の名前</label>
-      <input type="text" id="partner" placeholder="例：ユイ">
+      <input type="text" id="partner" placeholder="例：ユイシル">
     </div>
 
     <div class="form-group">
@@ -54,7 +54,7 @@
 
   <div class="filter">
     <label for="filter">相手別で絞り込み</label>
-    <input type="text" id="filter" oninput="renderEntries()" placeholder="例：ユイ">
+    <input type="text" id="filter" oninput="renderEntries()" placeholder="例：ユイシル">
   </div>
 
   <div id="entryList"></div>

--- a/js/ui.js
+++ b/js/ui.js
@@ -140,29 +140,55 @@ function renderEntries() {
       dateSpan.textContent = e.date;
       contentDiv.appendChild(dateSpan);
 
+      const contentWrapper = document.createElement("div");
+      contentWrapper.className = "content-wrapper";
+
       const contentSpan = document.createElement("span");
       contentSpan.className = "description";
       contentSpan.innerHTML = e.content.replace(
         /(https?:\/\/[^\s]+)/g,
         '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>'
       );
-      contentDiv.appendChild(contentSpan);
+      contentWrapper.appendChild(contentSpan);
 
       if (e.relatedEntries && e.relatedEntries.length > 0) {
         const relatedDiv = document.createElement("div");
         relatedDiv.className = "related-entries";
-        relatedDiv.style.marginTop = "0.5rem";
-        relatedDiv.style.fontSize = "0.9rem";
-        relatedDiv.style.color = "var(--text-color)";
-        relatedDiv.style.opacity = "0.7";
-        
         const relatedEntries = entries.filter(r => e.relatedEntries.includes(r.id));
         relatedDiv.innerHTML = `関連：<br>${relatedEntries.map(r => 
           `${r.date} - ${r.title}(${r.content})`
         ).join('<br>')}`;
-        
-        contentDiv.appendChild(relatedDiv);
+        contentWrapper.appendChild(relatedDiv);
       }
+
+      contentDiv.appendChild(contentWrapper);
+
+      // コンテンツの長さをチェックして、必要な場合のみボタンを表示
+      setTimeout(() => {
+        if (contentWrapper.scrollHeight > 100) {
+          const toggleButton = document.createElement("button");
+          toggleButton.className = "toggle-description";
+          toggleButton.innerHTML = `
+            もっと見る
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          `;
+          toggleButton.onclick = () => {
+            contentWrapper.classList.toggle('expanded');
+            toggleButton.innerHTML = contentWrapper.classList.contains('expanded') ? 
+              `閉じる
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="6 9 12 15 18 9"></polyline>
+              </svg>` :
+              `もっと見る
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="6 9 12 15 18 9"></polyline>
+              </svg>`;
+          };
+          contentDiv.appendChild(toggleButton);
+        }
+      }, 0);
 
       div.appendChild(contentDiv);
 


### PR DESCRIPTION
## Changes
- Modified to handle content and related entries as a single element
- Added control to show/hide "Show more" button based on content length
- Unified fade effect into a single element and modified to show only when content is long enough

## Technical Changes
1. CSS
   - Added `content-wrapper` element to wrap content and related entries
   - Applied fade effect to `content-wrapper`
   - Used `:has()` selector to control fade effect visibility based on content length

2. JavaScript
   - Wrapped content and related entries with `content-wrapper` element
   - Controlled entire content with a single "Show more" button
   - Performed height check on `content-wrapper`

## Testing
- Verified that collapsible functionality and fade effect are not shown when content is short (≤100px)
- Verified that collapsible functionality and fade effect are shown when content is long (>100px)
- Verified that fade effect is hidden when content is expanded