### PR TITLE
feat: Adjust UI to prevent overlap of feedback button and footer

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -6,7 +6,7 @@
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   margin: 0;
-  padding: 1rem 1rem 4rem 1rem;
+  padding: 1rem 1rem 6rem 1rem;
   background-color: var(--background-color);
   color: var(--text-color);
   line-height: 1.6;
@@ -73,7 +73,7 @@ h1 {
 .footer {
     text-align: center;
     padding: 1rem;
-    margin-top: 2rem;
+    margin-top: 1rem;
     color: var(--text-secondary);
     font-size: 0.9rem;
 }


### PR DESCRIPTION
Adjusted body bottom padding and footer style to prevent overlap between the fixed feedback button and the copyright display at the bottom of the page.