### PR TITLE
Add Google Analytics tracking and update privacy policy

### DIFF
--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -6,13 +6,8 @@
   <title>ユイシル α - プライバシーポリシー</title>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-1CLC4VX76Q"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-1CLC4VX76Q');
-  </script>
+  <script src="../js/analytics.js"></script>
+  <link rel="stylesheet" href="../css/variables.css">
   <style>
     :root {
       --primary-color: #faa987;

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -4,6 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ユイシル α - プライバシーポリシー</title>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1CLC4VX76Q"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-1CLC4VX76Q');
+  </script>
   <style>
     :root {
       --primary-color: #faa987;
@@ -140,6 +149,19 @@
     <div class="section">
       <h2>フィードバックフォームについて</h2>
       <p>本アプリのフィードバックフォーム（Google Forms）を通じて送信された情報は、Googleのプライバシーポリシーに従って取り扱われます。送信された情報は、本アプリの改善のためにのみ使用されます。</p>
+    </div>
+
+    <div class="section">
+      <h2>アクセス解析について</h2>
+      <p>本アプリでは、サービスの利用状況を把握するためにGoogle Analyticsを使用しています。Google Analyticsは、Cookieを使用して、個人を特定できない形式でアクセス情報を収集します。</p>
+      <p>収集される情報には以下のようなものがあります：</p>
+      <ul>
+        <li>アクセスしたページ</li>
+        <li>アクセスした時間</li>
+        <li>使用しているデバイスやブラウザの種類</li>
+        <li>アクセス元の地域</li>
+      </ul>
+      <p>これらの情報は、本アプリの改善のためにのみ使用されます。Google Analyticsの利用規約およびプライバシーポリシーについては、<a href="https://policies.google.com/technologies/partner-sites" target="_blank" rel="noopener noreferrer">Google Analyticsのウェブサイト</a>をご確認ください。</p>
     </div>
 
     <a href="../index.html" class="back-link">← トップページに戻る</a>

--- a/docs/terms.html
+++ b/docs/terms.html
@@ -6,13 +6,8 @@
   <title>ユイシル α - 利用規約</title>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-1CLC4VX76Q"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-1CLC4VX76Q');
-  </script>
+  <script src="../js/analytics.js"></script>
+  <link rel="stylesheet" href="../css/variables.css">
   <style>
     :root {
       --primary-color: #faa987;

--- a/docs/terms.html
+++ b/docs/terms.html
@@ -4,6 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ユイシル α - 利用規約</title>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1CLC4VX76Q"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-1CLC4VX76Q');
+  </script>
   <style>
     :root {
       --primary-color: #faa987;

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -6,13 +6,8 @@
   <title>ユイシル α - 使い方</title>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-1CLC4VX76Q"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-1CLC4VX76Q');
-  </script>
+  <script src="../js/analytics.js"></script>
+  <link rel="stylesheet" href="../css/variables.css">
   <style>
     :root {
       --primary-color: #faa987;

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -4,6 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ユイシル α - 使い方</title>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1CLC4VX76Q"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-1CLC4VX76Q');
+  </script>
   <style>
     :root {
       --primary-color: #faa987;

--- a/index.html
+++ b/index.html
@@ -4,6 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <title>ユイシル α</title>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1CLC4VX76Q"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-1CLC4VX76Q');
+  </script>
   <link rel="stylesheet" href="css/variables.css">
   <link rel="stylesheet" href="css/main.css">
   <link rel="stylesheet" href="css/components.css">

--- a/index.html
+++ b/index.html
@@ -6,13 +6,7 @@
   <title>ユイシル α</title>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-1CLC4VX76Q"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-1CLC4VX76Q');
-  </script>
+  <script src="js/analytics.js"></script>
   <link rel="stylesheet" href="css/variables.css">
   <link rel="stylesheet" href="css/main.css">
   <link rel="stylesheet" href="css/components.css">

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -1,0 +1,5 @@
+// Google Analytics initialization
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', 'G-1CLC4VX76Q'); 


### PR DESCRIPTION
This PR adds Google Analytics tracking to all pages and updates the privacy policy to include information about GA usage.
## Changes
 - Created a common analytics.js file for GA initialization
 - Added GA tracking code to all HTML files:
     - index.html
     - docs/usage.html
     - docs/terms.html
     - docs/privacy.html
 - Updated privacy policy to include GA usage information
 - Added relative path handling for GA script in docs pages
## Review Checklist
- [x] GA tracking code is properly initialized
- [x] Privacy policy accurately describes GA usage
- [x] All pages load GA script correctly
- [x] No console errors related to GA
