### PR TITLE
Fix: Keep 'Received' button visible when form is open

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -44,12 +44,10 @@ function showForm(selected, entry = null) {
   mode = entry?.type || selected;
   const formArea = document.getElementById("formArea");
   const formTitle = document.getElementById("formTitle");
-  const receivedBtn = document.getElementById("receivedBtn");
   
   formArea.style.display = "block";
   formArea.className = mode === "sent" ? "" : "received-mode";
   formTitle.textContent = mode === "sent" ? "贈った記録" : "受け取った記録";
-  receivedBtn.style.display = mode === "sent" ? "block" : "none";
   
   if (entry) {
     document.getElementById("editingId").value = entry.id;


### PR DESCRIPTION
## Overview
- Fixed an issue where the "Received" button would disappear when the form was opened.
- The button now remains visible at all times, improving usability.

## Checklist
- [x] "Received" button is always visible, even when the form is open
- [x] No regression for the "Sent" button or other UI elements

Closes # (if applicable)